### PR TITLE
Ability to categorize feeds into groups

### DIFF
--- a/main.config.EXAMPLE
+++ b/main.config.EXAMPLE
@@ -1,7 +1,21 @@
-[rss]
+[group1]
 feeds = http://example.com/feed1.xml,
         http://example.com/feed2.xml
 
+[group2]
+feeds = http://other.com/feed1.xml,
+        http://other.com/feed2.xml
+
 [mail]
-sender = noreply@example.com
+# Configure one of the following sender options depending on the behavior
+# you want.
+
+# Use same sender address for all feed groups
+# sender = noreply@my-rss-project.appspotmail.com
+
+# Send updates for each feed group from
+# rss+groupname@my-rss-project.appspotmail.com, allowing for
+# filtering of feed e-mails by group.
+# sender_domain = my-rss-project.appspotmail.com
+
 recipients = recipient1@example.com, recipient2@example.com

--- a/main.config.EXAMPLE
+++ b/main.config.EXAMPLE
@@ -5,6 +5,9 @@ feeds = http://example.com/feed1.xml,
 [group2]
 feeds = http://other.com/feed1.xml,
         http://other.com/feed2.xml
+# In addition to the global config below, also include the following 
+# recipients for this feed.
+recipients = recipient3@example.com
 
 [mail]
 # Configure one of the following sender options depending on the behavior

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ def poll_blog(url, feedgroup_name):
             # Send email containing the new post
             message = mail.EmailMessage()
             message.sender = d.feed.title + " <%s>" % (sender_address(feedgroup_name))
-            message.to = [email.strip() for email in config.get("mail", "recipients").split(",")]
+            message.to = email_recipients(feedgroup_name)
             message.subject = entry.title
             message.html = MAIL_TEMPLATE % (entry.link, formatted_timestamp, entry.title, content)
             message.check_initialized()
@@ -103,6 +103,12 @@ def poll_blog(url, feedgroup_name):
             num_sent += 1
 
     return num_sent
+
+def email_recipients(feedgroup_name):
+    global_recipients = config.get("mail", "recipients").split(",")
+    if config.has_option(feedgroup_name, "recipients"):
+        global_recipients += config.get(feedgroup_name, "recipients").split(",")
+    return [email.strip() for email in global_recipients]
 
 def sender_address(feedgroup_name):
     if config.has_option("mail", "sender"):

--- a/main.py
+++ b/main.py
@@ -48,16 +48,14 @@ class BlogPost(ndb.Model):
         return self.get_by_id(post_id, parent=ancestor_key) == None
 
 def poll_blog(url, feedgroup_name):
+    # Count number of e-mails sent
     num_sent = 0
 
     # Download and parse blog RSS/Atom
     d = feedparser.parse(url)
 
     # Create an ancestor key based on the blog's url
-    try:
-        ancestor_key = ndb.Key("blog_id", d.feed.link)
-    except AttributeError:
-        return
+    ancestor_key = ndb.Key("blog_id", url)
 
     # Loop over all posts, starting with the oldest
     for entry in d['entries'][::-1]:


### PR DESCRIPTION
Each feed group is configurable with an optional recipients setting, which gets added to the recipient list for that group. This way certain group(s) can be distributed to a broader set of interested parties.